### PR TITLE
Fix snapshot parameter in Kafka Connect Mongo snapshot test

### DIFF
--- a/benchmarks/mongo-kafka-snapshot/kafka-connect/data/connector.json
+++ b/benchmarks/mongo-kafka-snapshot/kafka-connect/data/connector.json
@@ -7,7 +7,7 @@
         "database": "test",
         "collection": "users",
 
-        "startup.mode": "copy_existing",
+        "copy.existing": "true",
         "change.stream.full.document": "updateLookup",
 
         "output.schema.infer.value": "false",


### PR DESCRIPTION
### Description

Even though it's documented as such, the `startup.mode` doesn't trigger a snapshot, but the deprecated setting `copy.existing` works as expected.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/streaming-benchmarks/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
